### PR TITLE
Fix reset timer bug

### DIFF
--- a/dev-friend/extension.js
+++ b/dev-friend/extension.js
@@ -57,9 +57,11 @@ function activate(context) {
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand(resetTimerId, () => {
+        if (!timer.isPaused()) {
+            updateLocalStorage(context, timer); 
+        }
         vscode.window.showInformationMessage('Timer reset!');
         timer.pause();
-        updateLocalStorage(context, timer);
         clearInterval(this.hydrate);
         clearInterval(this.rest);
         clearInterval(this.sidebar);


### PR DESCRIPTION
Make a very minor fix to the reset timer so that local storage will no longer be updated twice if the user pauses and then resets. 