### PR TITLE
Fix undefined userdata 

### DIFF
--- a/dev-friend/dataProvider.js
+++ b/dev-friend/dataProvider.js
@@ -2,17 +2,23 @@ const vscode = require('vscode');
 
 class DataProvider {
   constructor(timer,userData) {
-    
     this.users = [
       {
         first: "Today",
-        position: { Hours: (userData[0].h + timer.time().h), Minutes: (userData[0].m + timer.time().m) },
+        position: { 
+            Hours: userData[0] === undefined ? timer.time().h : userData[0].h + timer.time().h, 
+            Minutes: userData[0] === undefined ? timer.time().m : userData[0].m + timer.time().m
+        },
       },
       {
         first: "Yesterday",
-        position: { Hours: userData[1].h, Minutes: userData[1].m },
-      },
+        position: { 
+            Hours: userData[1] === undefined ? 0 : userData[1].h, 
+            Minutes: userData[1] === undefined ? 0 : userData[1].m 
+        },
+      }
     ];
+
     this.userTreeItems = this.convertUsersToTreeItems();
   }
 


### PR DESCRIPTION
Userdata is undefined for a day a user doesn't do any coding on. For example, if they didn't do any coding on Aug 5, then there will be no entry created for Aug 5 in userdata. However, if they were to do coding on the day after, Aug 6, the extension will still try and access userdata[Aug 5] for yesterday's data, but this is undefined because there was no entry created. As a result, no stats show up in the sidebar because the constructor can't access "h" or "m" of undefined. 